### PR TITLE
rename "Default" visualization to "Global"

### DIFF
--- a/visualization-design.typ
+++ b/visualization-design.typ
@@ -29,13 +29,13 @@ The fesability of developing a plugin with grafana compatible with was a point o
 - Grafana Example Plugins: https://grafana.com/developers/plugin-tools/plugin-examples/
 - Grafana and D3.js: https://community.grafana.com/t/build-a-panel-plugin-with-d3-js/35450
 
-It is unlikely D3.js will be required for any visualization views other than the Default and Region views.
+It is unlikely D3.js will be required for any visualization views other than the Global and Region views.
 
 #figure(
   table(
     columns: 2,
     [*View*],[*Graph Type*],
-    [Default], [D3.js Force Graph],
+    [Global], [D3.js Force Graph],
     [Region], [D3.js Force Graph],
     [Latency Graph], [Grafana Panel],
     [Traffic Heat Map], [Grafana Panel],

--- a/visualization-requirements.typ
+++ b/visualization-requirements.typ
@@ -35,16 +35,16 @@ The load balancer will be showcased at the innovation exposition in April. To he
 
 There will be multiple types of visualizations to show different aspects of the system. They are as follows:
 
-=== Default
+=== Global
 
-The purpose of the default visualization is to show functionality and overall state of the balancer to an audience. As a result, it's expected that only one balancer will be on-screen at any given time for this visualization since its function is to communicate the concept of a load balancer and how it applies to OpenTogetherTube.
+The purpose of the global visualization is to show functionality and overall state of the balancer to an audience. As a result, it's expected that only one balancer will be on-screen at any given time for this visualization since its function is to communicate the concept of a load balancer and how it applies to OpenTogetherTube.
 
 #figure(
   image("figures/vis/basic-graph-visualizer.png"),
-  caption: "Figma Mockup of Default Balancer Visualization"
+  caption: "Figma Mockup of Global Balancer Visualization"
   )
 
-This figure represents the default case of one balancer being active, and no specific views/groupings (such as region) being active. As new monoliths are instantiated, they will appear on screen tethered to the balancer. As new rooms are instantiated, they will appear on-screen alongside the client that created them tethered to the appropriate monolith. Clients will not appear on-screen until they are connected to a room. When a monolith goes offline, the node representing it and any clients connected to that monolith should dissappear The room(s) connected to the (now disconnected) monolith should remain on-screen for some predetermined amount of time in the case a client connected to that room reconnects so it can be tethered to a new monolith.
+This figure represents the global case of one balancer being active, and no specific views/groupings (such as region) being active. As new monoliths are instantiated, they will appear on screen tethered to the balancer. As new rooms are instantiated, they will appear on-screen alongside the client that created them tethered to the appropriate monolith. Clients will not appear on-screen until they are connected to a room. When a monolith goes offline, the node representing it and any clients connected to that monolith should dissappear The room(s) connected to the (now disconnected) monolith should remain on-screen for some predetermined amount of time in the case a client connected to that room reconnects so it can be tethered to a new monolith.
 
 === Monolith View
 
@@ -66,7 +66,7 @@ The purpose of this visualization is to show the the scale of the load balancer,
   caption: "Figma Mockup of Region Visualization"
 )
 
-This visualization is a bit different than the others since multiple instances of the balancer will be on-screen at the same time. Balancer nodes will be unique, but grouping for monoliths, rooms, and clients will be active by default. No animations aside from node movement will be implemented since this visualization is expected to take the most screen space.
+This visualization is a bit different than the others since multiple instances of the balancer will be on-screen at the same time. Balancer nodes will be unique, but grouping for monoliths, rooms, and clients will be active by global. No animations aside from node movement will be implemented since this visualization is expected to take the most screen space.
 
 === Traffic Heat Map
 


### PR DESCRIPTION
Since visualization isn't a full web app anymore, I think the name "Global" would be a better fit what the visualization actually shows.
