### PR TITLE
Updates for expo booklet

### DIFF
--- a/balancer-design.typ
+++ b/balancer-design.typ
@@ -3,10 +3,11 @@
 == Internal Architecture
 
 #figure(
-	image("figures/balancer-internals-class.svg"),
+	image("figures/balancer-internals-class.svg", width: 90%),
 	caption: "Class diagram showing the structure and relationships between types in the Balancer.",
 ) <Figure::balancer-internals-class>
 
+#pagebreak()
 Shown in @Figure::balancer-internals-class is the internal structure of the Balancer. The Balancer will discover Monoiths using the `MonolithDiscoverer` (a process further described in @Chapter::ServiceDiscovery), and the `MonolithConnectionManager` will establish connections to each Monolith. `Balancer` will update `BalancerContext` according to the messages it receives from `BalancerLink`. `Balancer` will then use `BalancerContext` to route messages to the appropriate Monoliths. Clients work similarly, except that they establish connections to the Balancer via `BalancerService`. `BalancerService` handles proxying HTTP requests to the appropriate Monoliths, and also accepting and upgrading WebSocket connections.
 
 
@@ -142,7 +143,7 @@ In order for the Balancer to work with the Monolith, the Monolith must have load
 The Balancer, like the Monolith, exports Prometheus metrics at the `/api/status/metrics` endpoint. These metrics can be scraped by a Prometheus server and visualized using Grafana. Fly automatically scrapes metrics from all applications and provides a Prometheus data source for Grafana. They also host a Grafana instance for us, but we host our own Grafana instance so that we can have alerting enabled, and more control over configuration.
 
 #figure(
-	image("figures/vis/prom-metrics-collection.svg"),
+	image("figures/vis/prom-metrics-collection.svg", width: 70%),
 	caption: "Component diagram showing how the Balancer interacts with Fly, Prometheus, and Grafana. The same concept applies to the Monolith.",
 ) <Figure::prom-metrics-collection>
 

--- a/dev-plan/dev-plan.typ
+++ b/dev-plan/dev-plan.typ
@@ -67,8 +67,7 @@ Unit tests will be written for all functions and methods where it makes sense, u
 
 == Risks
 
-- The Rust ecosystem is still relatively young, and there may be some issues with the libraries we use.
-- Async Rust is still in its infancy, and there may be some issues with the libraries we use.
+- Both the Rust ecosystem and Async Rust are relatively young, and there may be some issues with the libraries we use.
 - We could fail to addequately account for all the possible race conditions that could occur in a distributed environment.
 
 == Assumptions

--- a/solution-overview.typ
+++ b/solution-overview.typ
@@ -5,7 +5,7 @@
 The Monolith's current internals is shown in @Figure::monolith-class-current. It heavily uses redis to communicate between the RoomManager and ClientManager. As clients send messages to the Monolith, the ClientManager handles them and sends them to the RoomManager. The RoomManager receives and processes the messages. Rooms are entirely managed by the RoomManager. When rooms send messages to clients, it must go back through the ClientManager. This is because the ClientManager is the only component that knows which clients are in which rooms.
 
 #figure(
-  image("figures/monolith/monolith-class-current.svg", width: 40%),
+  image("figures/monolith/monolith-class-current.svg", width: 50%),
   caption: "Class diagram for the Monolith's internals, before any changes were made to support the Balancer."
 ) <Figure::monolith-class-current>
 

--- a/use-cases.typ
+++ b/use-cases.typ
@@ -140,6 +140,8 @@
   caption: [Activity diagram for @UseCase::end-user],
 ) <Figure::use-case-enduser>
 
+#pagebreak()
+
 #usecase(
   [Interface with Visualization],
   description: [In this use case, a vistor comes up to our booth on the day of the innovation expo and interacts with the visualization for the load balancer. The visualization must be a completely separate system that the load balancer interacts with.],

--- a/user-interviews.typ
+++ b/user-interviews.typ
@@ -24,6 +24,7 @@ Interviewer:
 
 *If OTT kept having problems, would you continue to use it?*
 
+#pagebreak()
 
 == Interview: Jay Creamer
 
@@ -66,6 +67,8 @@ If OTT is down, I would use another service.
 
 It's different because I know you, so I would be more likely to continue using it. But if it was a service I didn't know, I would probably stop using it.
 
+#pagebreak()
+
 == Interview: Daniel Craig
 
 User: Daniel Craig (Friend, Student at Stevens Institute of Technology)\\
@@ -106,6 +109,8 @@ Probably would use Discord voice chat. I'd stream the video on Discord and watch
 *If OTT kept having problems, would you continue to use it?*
 
 No, because other platforms or services that are similar enough exist already like the Discord Youtube activity and screensharing. They don't work as well as OTT, but they work well enough that if there were problems with OTT I would use those instead.
+
+#pagebreak()
 
 == Interview: Elizabeth Foster
 
@@ -148,6 +153,7 @@ I would probably use Discord.
 
 If there were consistent problems, probably not. There are a lot of video sharing platforms out there. If the problems were fixed, I'd probably go back.
 
+#pagebreak()
 
 == Interview: Jakob Gibson
 
@@ -189,6 +195,8 @@ Probably just use Discord, or sent them the video and wait for them to respond.
 *If OTT kept having problems, would you continue to use it?*
 
 Probably not, if there were constant issues I probably wouldn't use it.
+
+#pagebreak()
 
 == Interview: Michael Smith
 


### PR DESCRIPTION
Closes #380 
- use more concise wording in risks section
- add pagebreaks between user interviews for clarity
- fix wonky pagebreak
- fix some more weird whitespace/pagebreaks between figures
