### PR TITLE
Bump Setup Typst to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           python-version: "3.12"
       - run: make lint
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         with:
           name: main.pdf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,10 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: yusancky/setup-typst@v2
-        id: setup-typst
+      - uses: typst-community/setup-typst@v4
         with:
-          version: "v0.11.0"
+          typst-version: "v0.11.0"
       - run: sudo apt-get install -y make
       - run: make
       - uses: actions/setup-python@v5


### PR DESCRIPTION
Bump [`typst-community/setup-typst`](https://github.com/typst-community/setup-typst) to v4

> [!IMPORTANT] 
> The action `yusancky/setup-typst` has officially been migrated to repository `typst-community/setup-typst`. See [announcement](https://github.com/yusancky/setup-typst/blob/main/announcement.md) for more information.